### PR TITLE
Add functionality to customize API URLs for sandbox and live environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ the [AndroidManifest.xml](android/src/main/AndroidManifest.xml) file.
 
 ### initialization
 
-Initialize the M-Pesa Daraja API with your credentials:
-
+Initialize the M-Pesa Daraja API with your credentials and environment :
+The default environment is set to `sandbox` if the `environment` parameter is not explicitly provided.
 ```dart
 void main() {
 
-FlutterMpesa.passConsumerCredentials(
+FlutterMpesa.mPesaConfig(
     consumerKey: "[CUSTOMER KEY IN M-PESA DARAJA]",
     consumerSecret: "[CUSTOMER SECRET IN M-PESA DARAJA]",
     securityCredential: "[SECURITY CREDENTIAL IN M-PESA DARAJA]",
+    environment: MpesaEnvironment.sandbox,
   );
 
   runApp(const MyApp());
@@ -62,7 +63,7 @@ FlutterMpesa.passConsumerCredentials(
 
 ### Access Token
 
-Generate access token using this method, make sure you have correctly specified and initialized customerKey, consumerSecret and securityCredential provided by [<span style="color: GREEN">**M-pesa Daraja API**</span>](https://developer.safaricom.co.ke/) otherwise an exception will be thrown.
+Generate access token using this method, make sure you have correctly specified and initialized customerKey, consumerSecret, securityCredential and environment provided by [<span style="color: GREEN">**M-pesa Daraja API**</span>](https://developer.safaricom.co.ke/) otherwise an exception will be thrown.
 
 **NOTE : YOU DON'T HAVE TO CALL THIS METHOD EVERY TIME YOU USE OTHER METHODS, I ALREADY DID THAT FOR INDIVIDUAL METHODS.**
 

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,2 +1,2 @@
-sdk.dir=/home/eiji-otieno/Android/Sdk
-flutter.sdk=/home/eiji-otieno/snap/flutter/common/flutter
+sdk.dir=C:\\Users\\mdzih\\AppData\\Local\\Android\\sdk
+flutter.sdk=C:\\flutter

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,10 +4,12 @@ import 'package:flutter_mpesa_package/flutter_mpesa_services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 void main() {
-  FlutterMpesa.passConsumerCredentials(
+  FlutterMpesa.mPesaConfig(
     consumerKey: "[]",
     consumerSecret: "[]",
     securityCredential: "[]",
+    environment: Environment.sandbox,
+
   );
   runApp(const MyApp());
 }
@@ -178,7 +180,7 @@ class _HomeState extends State<Home> {
                     TaxRemittanceSenderIdentifierType.tillNumber,
               ).then((value) => print(value));
             },
-            child: const Text("REVERSE TRANSACTION"),
+            child: const Text("TAX REMITTANCE"),
           ),
         ],
       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -98,14 +98,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -118,18 +110,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -171,10 +163,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -211,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -231,6 +223,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.0.5 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.0"

--- a/lib/enums.dart
+++ b/lib/enums.dart
@@ -1,3 +1,9 @@
+enum Environment {
+  sandbox,
+  production,
+}
+
+
 enum TransactionStatusIdentifierType {
   msisdn,
   tillNumber,

--- a/lib/flutter_mpesa_services.dart
+++ b/lib/flutter_mpesa_services.dart
@@ -3,24 +3,50 @@ import 'package:flutter_mpesa_package/enums.dart';
 import 'package:http/http.dart' as http;
 
 class FlutterMpesa {
-  //These lines declare three static variables: _consumerKey, _consumerSecret, and _securityCredential. The static keyword means that these variables belong to the class itself rather than an instance of the class. They are also nullable (String?), meaning they can hold either a string value or null.
+
+
 
   static String? _consumerKey;
   static String? _consumerSecret;
   static String? _securityCredential;
+  static String _baseUrl = _sandboxBaseUrl;
+  static const String _sandboxBaseUrl = 'https://sandbox.safaricom.co.ke';
+  static const String _liveBaseUrl = 'https://api.safaricom.co.ke';
 
-  // This is a static method named passConsumerCredentials that takes three required arguments: consumerKey, consumerSecret, and securityCredential. It doesn't return anything (void).
+  // Configures the flutter_mpesa_package package by setting the consumer credentials and environment for M-Pesa integration.
+  // This method allows the setting of consumer credentials and defines the environment for interacting with the M-Pesa Daraja API.
+  // The environment parameter, if provided, allows the selection of either a 'sandbox' or 'production' environment for the integration.
+  // If the environment parameter is not specified, the 'sandbox' environment is set by default.
+  // The URL base is adjusted accordingly based on the selected environment:
+  //   - For 'sandbox', the base URL is set to 'https://sandbox.safaricom.co.ke'.
+  //   - For 'production', the base URL is set to 'https://api.safaricom.co.ke'.
 
-  static void passConsumerCredentials({
+
+  /// @param consumerKey The consumer key required for accessing the M-Pesa Daraja API.
+  /// @param consumerSecret The consumer secret required for accessing the M-Pesa Daraja API.
+  /// @param securityCredential The security credential required for accessing the M-Pesa Daraja API.
+  /// @param environment An enum parameter to specify the environment (sandbox or production) for the M-Pesa integration.
+
+  static void mPesaConfig({
     required String consumerKey,
     required String consumerSecret,
     required String securityCredential,
+    Environment? environment,
   }) {
-    // The purpose of this method is to set the consumer credentials for accessing the M-Pesa Daraja API. The values for consumerKey, consumerSecret, and securityCredential are provided as arguments to the method.
 
     _consumerKey = consumerKey;
     _consumerSecret = consumerSecret;
     _securityCredential = securityCredential;
+    switch (environment) {
+      case Environment.sandbox:
+        _baseUrl= _sandboxBaseUrl;
+        break;
+      case Environment.production:
+        _baseUrl = _liveBaseUrl;
+        break;
+      default:
+        _baseUrl = _sandboxBaseUrl;
+    }
   }
 
   /// Retrieves an access token from the M-Pesa Daraja API for authentication.
@@ -52,7 +78,7 @@ You can use this function to obtain an access token required for subsequent requ
 
     // Set the URL to request the access token
     String tokenUrl =
-        'https://sandbox.safaricom.co.ke/oauth/v1/generate?grant_type=client_credentials';
+        '$_baseUrl/oauth/v1/generate?grant_type=client_credentials';
 
     // Send a GET request to the token URL with the headers
     final response = await http.get(Uri.parse(tokenUrl), headers: headers);
@@ -101,7 +127,7 @@ Finally, it returns the responseData if available.*/
         if (accessToken != null) {
           // Set the URL to generate the QR code
           String qrUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/qrcode/v1/generate';
+              '$_baseUrl/mpesa/qrcode/v1/generate';
 
           // Prepare the request body with the specified parameters
           Map<String, dynamic> requestBody = {
@@ -164,7 +190,7 @@ Finally, it returns the responseData if available.*/
         if (accessToken != null) {
           // Set the URL for initiating the Lipa na M-Pesa transaction
           String lipaNaMpesaUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/stkpush/v1/processrequest';
+              '$_baseUrl/mpesa/stkpush/v1/processrequest';
 
           // Prepare the request body with the specified parameters
           Map<String, dynamic> requestBody = {
@@ -230,7 +256,7 @@ Finally, it returns the responseData if available.*/
         if (accessToken != null) {
           // Set the URL for registering the C2B URL
           String c2bRegisterUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/c2b/v1/registerurl';
+              '$_baseUrl/mpesa/c2b/v1/registerurl';
 
           // Prepare the request body with the specified parameters
           Map<String, dynamic> requestBody = {
@@ -296,7 +322,7 @@ Finally, it returns the responseData if available.*/
         if (accessToken != null) {
           // Set the URL for initiating the B2C transaction
           String businessToCustomerUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/b2c/v1/paymentrequest';
+              '$_baseUrl/mpesa/b2c/v1/paymentrequest';
 
           // Prepare the request body with the specified parameters
           Map<String, dynamic> requestBody = {
@@ -368,7 +394,7 @@ Finally, it returns the responseData if available.*/
         if (accessToken != null) {
           // Set the URL for querying the transaction status
           String transactionQueryUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/transactionstatus/v1/query';
+              '$_baseUrl/mpesa/transactionstatus/v1/query';
 
           // Prepare the request body with the specified parameters
           Map<String, dynamic> requestBody = {
@@ -437,7 +463,7 @@ Finally, it returns the responseData if available.*/
         if (accessToken != null) {
           // Set the URL for querying the account balance
           String accountBalanceQueryUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/accountbalance/v1/query';
+              '$_baseUrl/mpesa/accountbalance/v1/query';
 
           // Prepare the request body with the specified parameters
           Map<String, dynamic> requestBody = {
@@ -507,7 +533,7 @@ Finally, it returns the responseData if available.*/
         if (accessToken != null) {
           // Set the URL for initiating the transaction reversal
           String reversalQueryUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/reversal/v1/request';
+              '$_baseUrl/mpesa/reversal/v1/request';
 
           // Prepare the request body with the specified parameters
           Map<String, dynamic> requestBody = {
@@ -576,7 +602,7 @@ Finally, it returns the responseData if available.*/
       (accessToken) async {
         if (accessToken != null) {
           String remittaxUrl =
-              'https://sandbox.safaricom.co.ke/mpesa/b2b/v1/remittax';
+              '$_baseUrl/mpesa/b2b/v1/remittax';
 
           Map<String, dynamic> requestBody = {
             "Initiator": initiator,


### PR DESCRIPTION
Introduced functionality to dynamically set the different environments sandbox and live based on user configuration.
Implemented a method `mPesaConfig` instead of  `passConsumerCredentials` allowing users to set consumer credentials and specify the environment (sandbox or production) for M-Pesa integration.
Introduced conditional logic to switch between sandbox and production environments, adjusting the base URL accordingly.
Included comments and documentation to clarify the purpose and usage of these modifications.
